### PR TITLE
WIP: Feature/Reflection docblock version to ^3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     },
     "require": {
-        "phpdocumentor/reflection-docblock": ">=3.0",
+        "phpdocumentor/reflection-docblock": "^3.0",
         "yiisoft/yii2": "^2.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     },
     "require": {
-        "phpdocumentor/reflection-docblock": "^2.0",
+        "phpdocumentor/reflection-docblock": ">=3.0",
         "yiisoft/yii2": "^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
```
$ php7.1 composer.phar why phpdocumentor/reflection-docblock
nuffic/yii2-docblock-form  dev-develop            requires  phpdocumentor/reflection-docblock (^2.0)              
phpspec/prophecy           1.8.0                  requires  phpdocumentor/reflection-docblock (^2.0|^3.0.2|^4.0)  
traffic/traffic-control-2  dev-feature/jwk-tests  requires  phpdocumentor/reflection-docblock (^2.0)   
```